### PR TITLE
Only set miter limit when line join is JOIN_MITER

### DIFF
--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocument.java
@@ -552,7 +552,7 @@ public class PDFDocument extends SizedDocument {
 				out.append(serialize(strokeNew.getLineWidth()))
 					.append(" w").append(EOL);
 			}
-			if (strokeNew.getMiterLimit() != strokeDefault.getMiterLimit()) {
+			if (strokeNew.getLineJoin() == BasicStroke.JOIN_MITER && strokeNew.getMiterLimit() != strokeDefault.getMiterLimit()) {
 				out.append(serialize(strokeNew.getMiterLimit()))
 					.append(" M").append(EOL);
 			}


### PR DESCRIPTION
When a miter limit is set and the join type is not ``JOIN_MITER`` Adobe Acrobat produces an error and does not display the line.

This PR changes the behavior in the way that the miter limit is only set when the join type is ``JOIN_MITER``