### PR TITLE
Fix getFontMetrics to use Font provided in parameters rather than in getFont()

### DIFF
--- a/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
@@ -733,7 +733,7 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 		BufferedImage bi =
 			new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB_PRE);
 	    Graphics g = bi.getGraphics();
-	    FontMetrics fontMetrics = g.getFontMetrics(getFont());
+	    FontMetrics fontMetrics = g.getFontMetrics(f);
 	    g.dispose();
 	    return fontMetrics;
 	}


### PR DESCRIPTION
Currently font provided in parameters is ignored and user must setFont() first, which isn't obvious.
