### PR TITLE
 Added SVG support for Path2D.WIND_EVEN_ODD

### DIFF
--- a/src/main/java/de/erichseifert/vectorgraphics2d/eps/EPSDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/eps/EPSDocument.java
@@ -31,6 +31,7 @@ import java.awt.color.ColorSpace;
 import java.awt.geom.Arc2D;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
@@ -259,7 +260,12 @@ class EPSDocument extends SizedDocument {
 			elements.add(getOutput(c.getValue(), c.getX(), c.getY()));
 		} else if (command instanceof FillShapeCommand) {
 			FillShapeCommand c = (FillShapeCommand) command;
-			elements.add(getOutput(c.getValue()) + " fill");
+			String fillMethod = " fill";
+			Shape shape = c.getValue();
+			if (shape instanceof Path2D && ((Path2D) shape).getWindingRule() == Path2D.WIND_EVEN_ODD) {
+				fillMethod = " eofill";
+			}
+			elements.add(getOutput(c.getValue()) + fillMethod);
 		} else if (command instanceof CreateCommand) {
 			elements.add("gsave");
 		} else if (command instanceof DisposeCommand) {

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocument.java
@@ -29,6 +29,7 @@ import java.awt.Shape;
 import java.awt.Stroke;
 import java.awt.color.ColorSpace;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Path2D;
 import java.awt.geom.PathIterator;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -505,9 +506,14 @@ class PDFDocument extends SizedDocument {
 			}
 		} else if (command instanceof FillShapeCommand) {
 			FillShapeCommand c = (FillShapeCommand) command;
+			String fillMethod = " f";
+			Shape shape = c.getValue();
+			if (shape instanceof Path2D && ((Path2D) shape).getWindingRule() == Path2D.WIND_EVEN_ODD) {
+				fillMethod = " f*";
+			}
 			try (ByteArrayOutputStream ba = new ByteArrayOutputStream()) {
 				ba.write(getOutput(c.getValue()));
-				ba.write(serialize(" f"));
+				ba.write(serialize(fillMethod));
 				s = ba.toByteArray();
 			} catch (IOException e) {
 				throw new IllegalStateException(e);

--- a/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
@@ -31,6 +31,7 @@ import java.awt.color.ColorSpace;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.RoundRectangle2D;
@@ -283,8 +284,14 @@ class SVGDocument extends SizedDocument {
 			addToGroup(e);
 		} else if (command instanceof FillShapeCommand) {
 			FillShapeCommand c = (FillShapeCommand) command;
-			Element e = getElement(c.getValue());
-			e.setAttribute("style", getStyle(true));
+			Shape shape = c.getValue();
+            Element e = getElement(shape);
+            if (shape instanceof Path2D) {
+                Path2D path = (Path2D) shape;
+                e.setAttribute("style", getStyle(true, path.getWindingRule() == Path2D.WIND_NON_ZERO));
+            } else {
+			    e.setAttribute("style", getStyle(true));
+            }
 			addToGroup(e);
 		}
 	}
@@ -348,7 +355,11 @@ class SVGDocument extends SizedDocument {
 		return false;
 	}
 
-	private String getStyle(boolean filled) {
+    private String getStyle(boolean filled) {
+        return getStyle(filled, true);
+    }
+    
+    private String getStyle(boolean filled, boolean fillRullNonZero) {
 		StringBuilder style = new StringBuilder();
 
 		Color color = getCurrentState().getColor();
@@ -359,6 +370,10 @@ class SVGDocument extends SizedDocument {
 			appendStyle(style, "fill", colorOutput);
 			if (color.getAlpha() < 255) {
 				appendStyle(style, "fill-opacity", opacity);
+			}
+			if (!fillRullNonZero) {
+			    // nonzero is the default; only need to set the style rule for non-default evenodd winding rule.
+			    appendStyle(style, "fill-rule", "evenodd");
 			}
 		} else {
 			appendStyle(style, "fill", "none");

--- a/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
@@ -285,13 +285,13 @@ class SVGDocument extends SizedDocument {
 		} else if (command instanceof FillShapeCommand) {
 			FillShapeCommand c = (FillShapeCommand) command;
 			Shape shape = c.getValue();
-            Element e = getElement(shape);
-            if (shape instanceof Path2D) {
-                Path2D path = (Path2D) shape;
-                e.setAttribute("style", getStyle(true, path.getWindingRule() == Path2D.WIND_NON_ZERO));
-            } else {
-			    e.setAttribute("style", getStyle(true));
-            }
+			Element e = getElement(shape);
+			if (shape instanceof Path2D) {
+				Path2D path = (Path2D) shape;
+				e.setAttribute("style", getStyle(true, path.getWindingRule() == Path2D.WIND_NON_ZERO));
+			} else {
+				e.setAttribute("style", getStyle(true));
+			}
 			addToGroup(e);
 		}
 	}
@@ -355,11 +355,11 @@ class SVGDocument extends SizedDocument {
 		return false;
 	}
 
-    private String getStyle(boolean filled) {
-        return getStyle(filled, true);
-    }
-    
-    private String getStyle(boolean filled, boolean fillRullNonZero) {
+	private String getStyle(boolean filled) {
+		return getStyle(filled, true);
+	}
+	
+	private String getStyle(boolean filled, boolean fillRullNonZero) {
 		StringBuilder style = new StringBuilder();
 
 		Color color = getCurrentState().getColor();
@@ -372,8 +372,8 @@ class SVGDocument extends SizedDocument {
 				appendStyle(style, "fill-opacity", opacity);
 			}
 			if (!fillRullNonZero) {
-			    // nonzero is the default; only need to set the style rule for non-default evenodd winding rule.
-			    appendStyle(style, "fill-rule", "evenodd");
+				// nonzero is the default; only need to set the style rule for non-default evenodd winding rule.
+				appendStyle(style, "fill-rule", "evenodd");
 			}
 		} else {
 			appendStyle(style, "fill", "none");

--- a/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
@@ -91,24 +91,6 @@ public class SVGProcessorTest {
 
 	@Test
 	public void fillShapeBlackEvenOdd() throws Exception {
-	    // Example based on java.awt.LineBorder
-        Rectangle2D rectOuter = new Rectangle2D.Double(0, 0, 10, 10);
-	    Rectangle2D rectInner = new Rectangle2D.Double(1, 1, 8, 8);
-	    Path2D path = new Path2D.Double(Path2D.WIND_EVEN_ODD);
-	    path.append(rectOuter, false);
-	    path.append(rectInner, false);
-		String result = process(
-			new FillShapeCommand(path)
-		);
-		String expected =
-			HEADER + EOL +
-			"  <path d=\"M0,0 L10.0,0 L10.0,10 L0.0,10 L0.0,0 Z M1,1 L9.0,1 L9.0,9 L1.0,9 L1.0,1 Z\" style=\"fill:rgb(255,255,255);fill-rule:evenodd;stroke:none;\"/>" + EOL +
-			FOOTER;
-		assertXMLEquals(expected, result);
-	}
-
-	@Test
-	public void fillShapeBlackEvenOdd() throws Exception {
 		// Example based on java.awt.LineBorder
 		Rectangle2D rectOuter = new Rectangle2D.Double(0, 0, 10, 10);
 		Rectangle2D rectInner = new Rectangle2D.Double(1, 1, 8, 8);

--- a/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
@@ -23,6 +23,7 @@ package de.erichseifert.vectorgraphics2d.svg;
 
 import static de.erichseifert.vectorgraphics2d.TestUtils.assertXMLEquals;
 
+import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -76,14 +77,32 @@ public class SVGProcessorTest {
 		assertXMLEquals(expected, result);
 	}
 
+    @Test
+    public void fillShapeBlack() throws Exception {
+        String result = process(
+            new FillShapeCommand(new Rectangle2D.Double(1, 2, 3, 4))
+        );
+        String expected =
+            HEADER + EOL +
+            "  <rect height=\"4\" style=\"fill:rgb(255,255,255);stroke:none;\" width=\"3\" x=\"1\" y=\"2\"/>" + EOL +
+            FOOTER;
+        assertXMLEquals(expected, result);
+    }
+
 	@Test
-	public void fillShapeBlack() throws Exception {
+	public void fillShapeBlackEvenOdd() throws Exception {
+	    // Example based on java.awt.LineBorder
+        Rectangle2D rectOuter = new Rectangle2D.Double(0, 0, 10, 10);
+	    Rectangle2D rectInner = new Rectangle2D.Double(1, 1, 8, 8);
+	    Path2D path = new Path2D.Double(Path2D.WIND_EVEN_ODD);
+	    path.append(rectOuter, false);
+	    path.append(rectInner, false);
 		String result = process(
-			new FillShapeCommand(new Rectangle2D.Double(1, 2, 3, 4))
+			new FillShapeCommand(path)
 		);
 		String expected =
 			HEADER + EOL +
-			"  <rect height=\"4\" style=\"fill:rgb(255,255,255);stroke:none;\" width=\"3\" x=\"1\" y=\"2\"/>" + EOL +
+			"  <path d=\"M0,0 L10.0,0 L10.0,10 L0.0,10 L0.0,0 Z M1,1 L9.0,1 L9.0,9 L1.0,9 L1.0,1 Z\" style=\"fill:rgb(255,255,255);fill-rule:evenodd;stroke:none;\"/>" + EOL +
 			FOOTER;
 		assertXMLEquals(expected, result);
 	}

--- a/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
@@ -106,4 +106,22 @@ public class SVGProcessorTest {
 			FOOTER;
 		assertXMLEquals(expected, result);
 	}
+
+	@Test
+	public void fillShapeBlackEvenOdd() throws Exception {
+		// Example based on java.awt.LineBorder
+		Rectangle2D rectOuter = new Rectangle2D.Double(0, 0, 10, 10);
+		Rectangle2D rectInner = new Rectangle2D.Double(1, 1, 8, 8);
+		Path2D path = new Path2D.Double(Path2D.WIND_EVEN_ODD);
+		path.append(rectOuter, false);
+		path.append(rectInner, false);
+		String result = process(
+			new FillShapeCommand(path)
+		);
+		String expected =
+			HEADER + EOL +
+			"  <path d=\"M0,0 L10.0,0 L10.0,10 L0.0,10 L0.0,0 Z M1,1 L9.0,1 L9.0,9 L1.0,9 L1.0,1 Z\" style=\"fill:rgb(255,255,255);fill-rule:evenodd;stroke:none;\"/>" + EOL +
+			FOOTER;
+		assertXMLEquals(expected, result);
+	}
 }


### PR DESCRIPTION
This fixes a bug where setting e.g. a java.awt.LineBorder on a JPanel
results in a solid-fill rectangle obscuring the contents.

Unfortunately I don't know the corresponding fix for PDF and EPS.

A little background:
We're converting SVG export for our project (IGV) over from Batik as it's not ready for Java 9+ and is too heavyweight anyway.  We considered writing our own exporter but yours is already in good shape.  We found a couple of bugs in testing.  This is the first and was pretty easy; we'll see how the next one goes.

Here's the [relevant part of the spec](https://www.w3.org/TR/SVG/painting.html#FillRuleProperty).