### PR TITLE
Partial fix for issue #68: Managing GraphicsState with a Stack is unsafe

### DIFF
--- a/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
@@ -106,12 +106,15 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 
 	private GraphicsState state;
 	
-	private CreateCommand parentCreateCommand;
+	/** Parent Command linked to all other Commands created by this graphics object.  This will
+	 *  be used to track the appropriate GraphicsState for each Command during Document processing. 
+	 */
+	private CreateCommand parentCommand;
 
 	public VectorGraphics2D() {
 		this.commands = new MutableCommandSequence();
-		parentCreateCommand = new CreateCommand(this);
-		emit(parentCreateCommand);
+		parentCommand = new CreateCommand(this);
+		emit(parentCommand);
 		GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
 		GraphicsDevice graphicsDevice = null;
 		if (!graphicsEnvironment.isHeadlessInstance()) {
@@ -135,8 +138,10 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 	public Object clone() throws CloneNotSupportedException {
 		VectorGraphics2D clone = (VectorGraphics2D) super.clone();
 		clone.state = (GraphicsState) state.clone();
-		clone.parentCreateCommand = new CreateCommand(clone);
-//		clone.parentCreateCommand.setParentCreateCommand(parentCreateCommand);
+		// Create a clone.parentCommand linked to the clone Graphics object,
+		// but with the current instance's command as its parent.
+		clone.parentCommand = new CreateCommand(clone);
+		clone.parentCommand.setParent(parentCommand);
 		return clone;
 	}
 
@@ -532,7 +537,7 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 		VectorGraphics2D clone = null;
 		try {
 			clone = (VectorGraphics2D) this.clone();
-			emit(clone.parentCreateCommand);
+			emit(clone.parentCommand);
 		} catch (CloneNotSupportedException e) {
 			e.printStackTrace();
 		}
@@ -793,7 +798,9 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 	}
 
 	private void emit(Command<?> command) {
-		command.setParentCreateCommand(parentCreateCommand);
+		// Patch in the instance's parentCommand
+		// TODO: consider whether this should be done via the Command's constructor instead.
+		command.setParent(parentCommand);
 		commands.add(command);
 	}
 

--- a/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
@@ -105,10 +105,13 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 	private boolean disposed;
 
 	private GraphicsState state;
+	
+	private CreateCommand parentCreateCommand;
 
 	public VectorGraphics2D() {
 		this.commands = new MutableCommandSequence();
-		emit(new CreateCommand(this));
+		parentCreateCommand = new CreateCommand(this);
+		emit(parentCreateCommand);
 		GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
 		GraphicsDevice graphicsDevice = null;
 		if (!graphicsEnvironment.isHeadlessInstance()) {
@@ -132,6 +135,8 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 	public Object clone() throws CloneNotSupportedException {
 		VectorGraphics2D clone = (VectorGraphics2D) super.clone();
 		clone.state = (GraphicsState) state.clone();
+		clone.parentCreateCommand = new CreateCommand(clone);
+//		clone.parentCreateCommand.setParentCreateCommand(parentCreateCommand);
 		return clone;
 	}
 
@@ -527,7 +532,7 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 		VectorGraphics2D clone = null;
 		try {
 			clone = (VectorGraphics2D) this.clone();
-			emit(new CreateCommand(clone));
+			emit(clone.parentCreateCommand);
 		} catch (CloneNotSupportedException e) {
 			e.printStackTrace();
 		}
@@ -788,6 +793,7 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 	}
 
 	private void emit(Command<?> command) {
+		command.setParentCreateCommand(parentCreateCommand);
 		commands.add(command);
 	}
 

--- a/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
@@ -113,6 +113,8 @@ public class VectorGraphics2D extends Graphics2D implements Cloneable {
 
 	public VectorGraphics2D() {
 		this.commands = new MutableCommandSequence();
+		// Note that this instance will have itself as a parent (via the emit() call).  That self
+		// relationship will be used to mark the top-most instance.
 		parentCommand = new CreateCommand(this);
 		emit(parentCommand);
 		GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Command.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Command.java
@@ -25,7 +25,7 @@ import java.util.Locale;
 
 public abstract class Command<T> {
 	private final T value;
-	private CreateCommand parentCreateCommand;
+	private CreateCommand parent;
 
 	public Command(T value) {
 		this.value = value;
@@ -35,12 +35,12 @@ public abstract class Command<T> {
 		return value;
 	}
 
-	public CreateCommand getParentCreateCommand() {
-		return parentCreateCommand;
+	public CreateCommand getParent() {
+		return parent;
 	}
 
-	public void setParentCreateCommand(CreateCommand parentCreateCommand) {
-		this.parentCreateCommand = parentCreateCommand;
+	public void setParent(CreateCommand parent) {
+		this.parent = parent;
 	}
 
 	@Override

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Command.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Command.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 
 public abstract class Command<T> {
 	private final T value;
+	private CreateCommand parentCreateCommand;
 
 	public Command(T value) {
 		this.value = value;
@@ -32,6 +33,14 @@ public abstract class Command<T> {
 
 	public T getValue() {
 		return value;
+	}
+
+	public CreateCommand getParentCreateCommand() {
+		return parentCreateCommand;
+	}
+
+	public void setParentCreateCommand(CreateCommand parentCreateCommand) {
+		this.parentCreateCommand = parentCreateCommand;
 	}
 
 	@Override

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/CreateCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/CreateCommand.java
@@ -21,11 +21,22 @@
  */
 package de.erichseifert.vectorgraphics2d.intermediate.commands;
 
+import de.erichseifert.vectorgraphics2d.GraphicsState;
 import de.erichseifert.vectorgraphics2d.VectorGraphics2D;
 
 public class CreateCommand extends StateCommand<VectorGraphics2D> {
+	private GraphicsState processingState;
+	
 	public CreateCommand(VectorGraphics2D graphics) {
 		super(graphics);
+	}
+
+	public GraphicsState getProcessingState() {
+		return processingState;
+	}
+
+	public void setProcessingState(GraphicsState processingState) {
+		this.processingState = processingState;
 	}
 }
 

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilter.java
@@ -73,7 +73,7 @@ public class AbsoluteToRelativeTransformsFilter extends StreamingFilter {
 			}
 			relativeTransform.concatenate(absoluteTransform);
 			TransformCommand transformCommand = new TransformCommand(relativeTransform);
-			transformCommand.setParentCreateCommand(command.getParentCreateCommand());
+			transformCommand.setParent(command.getParent());
 			return Collections.<Command<?>>singletonList(transformCommand);
 		}
 		return Collections.<Command<?>>singletonList(command);

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilter.java
@@ -73,6 +73,7 @@ public class AbsoluteToRelativeTransformsFilter extends StreamingFilter {
 			}
 			relativeTransform.concatenate(absoluteTransform);
 			TransformCommand transformCommand = new TransformCommand(relativeTransform);
+			transformCommand.setParentCreateCommand(command.getParentCreateCommand());
 			return Collections.<Command<?>>singletonList(transformCommand);
 		}
 		return Collections.<Command<?>>singletonList(command);

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilter.java
@@ -75,7 +75,7 @@ public class FillPaintedShapeAsImageFilter extends StreamingFilter {
 		imageGraphics.dispose();
 
 		DrawImageCommand drawImageCommand = new DrawImageCommand(image, imageWidth, imageHeight, x, y, width, height);
-		drawImageCommand.setParentCreateCommand(paintCommand.getParentCreateCommand());
+		drawImageCommand.setParent(paintCommand.getParent());
 		return drawImageCommand;
 	}
 

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilter.java
@@ -74,7 +74,9 @@ public class FillPaintedShapeAsImageFilter extends StreamingFilter {
 		imageGraphics.fill(shape);
 		imageGraphics.dispose();
 
-		return new DrawImageCommand(image, imageWidth, imageHeight, x, y, width, height);
+		DrawImageCommand drawImageCommand = new DrawImageCommand(image, imageWidth, imageHeight, x, y, width, height);
+		drawImageCommand.setParentCreateCommand(paintCommand.getParentCreateCommand());
+		return drawImageCommand;
 	}
 
 	@Override

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilter.java
@@ -59,7 +59,10 @@ public abstract class GroupingFilter extends StreamingFilter {
 				group = new Group();
 			}
 			group.add(command);
-			group.setParentCreateCommand(command.getParentCreateCommand());
+			
+			// Update the group's parent as we go; unlike other commands, the group must be associated
+			// with the *final* command's state as it is created after all those commands are applied.
+			group.setParent(command.getParent());
 			return null;
 		}
 		return Collections.<Command<?>>singletonList(command);

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilter.java
@@ -59,6 +59,7 @@ public abstract class GroupingFilter extends StreamingFilter {
 				group = new Group();
 			}
 			group.add(command);
+			group.setParentCreateCommand(command.getParentCreateCommand());
 			return null;
 		}
 		return Collections.<Command<?>>singletonList(command);

--- a/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
@@ -333,6 +333,10 @@ class SVGDocument extends SizedDocument {
 			} else if (command instanceof CreateCommand) {
 				CreateCommand c = (CreateCommand) command;
 				try {
+					// Inject an cloned instance of GraphicsState into the CreateCommand for
+					// use by all Commands that were created by its Graphics object.
+					// For the top-most instance (self reference to parent) use a clone of
+					// the defaultState, otherwise use a clone of the parent's state.
 					CreateCommand parent = c.getParent();
 					if (c != parent && state != null) {
 						c.setProcessingState((GraphicsState) state.clone());


### PR DESCRIPTION
This is a partial fix.  The idea here is similar to what was discussed in that Issue thread.  We associate every Command with a "parent" CreateCommand linking to the VectorGraphics2D in which that command was emitted.  Then, during rendering we can link to a clean GraphicsState to track the modifications made by those Commands *only* so rendering "within" each CreateCommand can happen independently.

Arguably it would be better for every Command to accept its parent via a constructor arg, but that would have made this PR big and unwieldy and harder to review.  So this was kind of a way to introduce the concept in a more controlled way since it affects fewer call sites.

Also, this only fixes SVG and PDF but not EPS as that doesn't use the Stack concept directly.  I'm not quite sure how to fix this for EPS, so hopefully someone else can pick it up from there.

Unfortunately, we're still seeing further bugs and their cause is not clear.  Our project team has decided to stick with Batik after all since their latest release works with Java 9+ so I can't pursue this any more for now.  It was really close but we just didn't have the resources to go further.

We may have to pick this up again for a different project, though, so I may be back with more fixes.

Thanks, hope this helps!