### PR TITLE
Update license headers 2019

### DIFF
--- a/src/main/java/de/erichseifert/vectorgraphics2d/Document.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/Document.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/GraphicsState.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/GraphicsState.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/Processor.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/Processor.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/Processors.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/Processors.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/SizedDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/SizedDocument.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/VectorGraphics2D.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/VectorHints.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/VectorHints.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/eps/EPSDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/eps/EPSDocument.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/eps/EPSProcessor.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/eps/EPSProcessor.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/eps/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/eps/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/CommandSequence.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/CommandSequence.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/MutableCommandSequence.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/MutableCommandSequence.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/AffineTransformCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/AffineTransformCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Command.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Command.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/CreateCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/CreateCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DisposeCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DisposeCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DrawImageCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DrawImageCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DrawShapeCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DrawShapeCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DrawStringCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/DrawStringCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/FillShapeCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/FillShapeCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Group.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/Group.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/RotateCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/RotateCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/ScaleCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/ScaleCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetBackgroundCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetBackgroundCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetClipCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetClipCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetColorCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetColorCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetCompositeCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetCompositeCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetFontCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetFontCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetHintCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetHintCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetPaintCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetPaintCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetStrokeCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetStrokeCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetTransformCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetTransformCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetXORModeCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/SetXORModeCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/ShearCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/ShearCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/StateCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/StateCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/TransformCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/TransformCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/TranslateCommand.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/TranslateCommand.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/commands/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/Filter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/Filter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/OptimizeFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/OptimizeFilter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/StateChangeGroupingFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/StateChangeGroupingFilter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/StreamingFilter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/StreamingFilter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/filters/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/intermediate/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/DefaultPDFObject.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/DefaultPDFObject.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocument.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFObject.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFObject.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFProcessor.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PDFProcessor.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Page.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Page.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PageTreeNode.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/PageTreeNode.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Payload.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Payload.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Resources.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Resources.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Stream.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/Stream.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/TrueTypeFont.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/TrueTypeFont.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/pdf/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/pdf/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGDocument.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessor.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessor.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/svg/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/svg/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/ASCII85EncodeStream.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/ASCII85EncodeStream.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/AlphaToMaskOp.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/AlphaToMaskOp.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/Base64EncodeStream.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/Base64EncodeStream.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/DataUtils.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/DataUtils.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/FlateEncodeStream.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/FlateEncodeStream.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/FormattingWriter.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/FormattingWriter.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/GraphicsUtils.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/GraphicsUtils.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/ImageDataStream.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/ImageDataStream.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/LineWrapOutputStream.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/LineWrapOutputStream.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/PageSize.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/PageSize.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/main/java/de/erichseifert/vectorgraphics2d/util/package-info.java
+++ b/src/main/java/de/erichseifert/vectorgraphics2d/util/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/AllTests.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/AllTests.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/GraphicsStateTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/GraphicsStateTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/ProcessorsTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/ProcessorsTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/TestUtils.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/TestUtils.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/TestUtilsTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/TestUtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/VectorGraphics2DTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/VectorGraphics2DTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/eps/EPSProcessorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/eps/EPSProcessorTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/eps/EPSTests.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/eps/EPSTests.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/IRTests.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/IRTests.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/MutableCommandSequenceTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/MutableCommandSequenceTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilterTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/AbsoluteToRelativeTransformsFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilterTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FillPaintedShapeAsImageFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FilterTests.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/FilterTests.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilterTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/GroupingFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/StreamingFilterTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/intermediate/filters/StreamingFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/package-info.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/package-info.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocumentTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PDFDocumentTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PDFProcessorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PDFProcessorTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PDFTests.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PDFTests.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PageTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PageTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PageTreeNodeTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/pdf/PageTreeNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/pdf/StreamTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/pdf/StreamTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGProcessorTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGTests.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/svg/SVGTests.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/util/ASCII85EncodeStreamTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/util/ASCII85EncodeStreamTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/util/Base64EncodeStreamTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/util/Base64EncodeStreamTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/util/DataUtilsTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/util/DataUtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/util/FormattingWriterTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/util/FormattingWriterTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/util/GraphicsUtilsTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/util/GraphicsUtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/util/PageSizeTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/util/PageSizeTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/util/UtilTests.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/util/UtilTests.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/CharacterTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/CharacterTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/ClippingTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/ClippingTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/CmykColorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/CmykColorTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/ColorTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/ColorTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/EmptyFileTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/EmptyFileTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/FontTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/FontTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/ImageTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/ImageTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/PaintTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/PaintTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/ShapesTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/ShapesTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/StrokeTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/StrokeTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/SwingExportTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/SwingExportTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/TestBrowser.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/TestBrowser.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/TestCase.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/TestCase.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.

--- a/src/test/java/de/erichseifert/vectorgraphics2d/visual/TransformTest.java
+++ b/src/test/java/de/erichseifert/vectorgraphics2d/visual/TransformTest.java
@@ -1,7 +1,7 @@
 /*
  * VectorGraphics2D: Vector export for Java(R) Graphics2D
  *
- * (C) Copyright 2010-2018 Erich Seifert <dev[at]erichseifert.de>,
+ * (C) Copyright 2010-2019 Erich Seifert <dev[at]erichseifert.de>,
  * Michael Seifert <mseifert[at]error-reports.org>
  *
  * This file is part of VectorGraphics2D.


### PR DESCRIPTION
Updates license headers to 2019. The CI pipeline will fail, though. A fix for Travis CI is provided in https://github.com/eseifert/vectorgraphics2d/pull/70