### PR TITLE
Gradle: set an Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,12 @@ license {
     ext.email2 = owner2_email
 }
 
+jar {
+    manifest {
+      attributes('Automatic-Module-Name': 'de.erichseifert.vectorgraphics2d')
+    }
+}
+
 task shrinkJar(type: proguard.gradle.ProGuardTask, dependsOn: jar) {
     description = 'Uses ProGuard to reduce the code size of this project.'
     group = 'Build'


### PR DESCRIPTION
This simple patch is intended to set an automatic module name in the Jar file's MANIFEST. Unfortunately, I have been unable to test the outcome of the patch due to the Gradle build being a bit entangled with repository deployment, but I have applied this kind of change to other projects and it works.

Fixes #76.