### PR TITLE
Gradle build improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Eclipse
+/.project
+/.classpath
+/.settings/
+/bin/
+
+# Intellij IDEA
+.idea/
+*.iml
+*.iws
+
+# Gradle
+/.gradle
+/build/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
-apply plugin: 'java'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
 
 group = 'de.erichseifert.vectorgraphics2d'
 version = getVersionString()
@@ -19,7 +18,9 @@ ext {
     website = 'https://github.com/eseifert/vectorgraphics2d/'
 
     // Determine the location of rt.jar (required for ProGuard)
-    if (System.getProperty('os.name').startsWith('Mac')) {
+    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+        runtimeJar = "${System.getProperty("java.home")}/jmods"
+    } else if (System.getProperty('os.name').startsWith('Mac')) {
         runtimeJar = "${System.getProperty("java.home")}/bundle/Classes/classes.jar"
     } else {
         runtimeJar = "${System.getProperty("java.home")}/lib/rt.jar"
@@ -33,11 +34,11 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.ghost4j:ghost4j:1.0.1'
-    testCompile 'org.apache.xmlgraphics:batik-transcoder:1.9.1'
-    testRuntime 'org.apache.xmlgraphics:batik-codec:1.9.1'  // Required for images with data: URLs
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.ghost4j:ghost4j:1.0.1'
+    testImplementation 'org.apache.xmlgraphics:batik-transcoder:1.9.1'
+    testRuntimeOnly 'org.apache.xmlgraphics:batik-codec:1.9.1'  // Required for images with data: URLs
 }
 
 buildscript {
@@ -47,11 +48,16 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.sf.proguard:proguard-gradle:5.2.+'
-        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.+'
-        classpath 'net.saliman:gradle-cobertura-plugin:3.0.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1'
+        classpath 'com.guardsquare:proguard-gradle:7.2.1'
+        classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
+        classpath 'net.saliman:gradle-cobertura-plugin:4.0.0'
+        classpath 'gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.0'
     }
+}
+
+java {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 apply plugin: 'net.saliman.cobertura'
@@ -59,6 +65,7 @@ cobertura.coverageFormats = ['html', 'xml']
 
 apply plugin: 'com.github.kt3k.coveralls'
 
+/*
 apply plugin: 'license'
 license {
     header(rootProject.file("${projectDir}/src/etc/header.txt"))
@@ -73,7 +80,7 @@ license {
     ext.email1 = owner1_email
     ext.owner2 = owner2_name
     ext.email2 = owner2_email
-}
+}*/
 
 jar {
     manifest {
@@ -88,9 +95,9 @@ task shrinkJar(type: proguard.gradle.ProGuardTask, dependsOn: jar) {
     configuration("${projectDir}/src/etc/proguard.conf")
     target(targetCompatibility.toString())
     injars(jar.archivePath)
-    outjars("${libsDir}/shrunk/${jar.archiveName}")
+    outjars("${buildDir}/tmp/shrunk/${jar.archiveName}")
     libraryjars(runtimeJar)
-    libraryjars(configurations.runtime)
+    libraryjars(configurations.runtimeClasspath)
 }
 
 task sourceJar(type: Jar) {
@@ -107,7 +114,6 @@ task javadocJar(type: Jar) {
     classifier 'javadoc'
 }
 
-apply plugin: 'maven'
 apply plugin: 'signing'
 
 artifacts {
@@ -115,56 +121,64 @@ artifacts {
 }
 
 signing {
-    required { hasProperty('signing.keyId') && gradle.taskGraph.hasTask('uploadArchives') }
+    required { hasProperty('signing.keyId') }
     sign configurations.archives
 }
 
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                authentication(userName: project.hasProperty('ossrhUsername')?ossrhUsername:'', password: project.hasProperty('ossrhPassword')?ossrhPassword:'')
-            }
-
-            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-                authentication(userName: project.hasProperty('ossrhUsername')?ossrhUsername:'', password: project.hasProperty('ossrhPassword')?ossrhPassword:'')
-            }
-
-            pom.project {
-                name rootProject.name
-                packaging 'jar'
-                description project.description
-                url website
-                inceptionYear inceptionYear
+publishing {
+    publications {
+        maven(MavenPublication) {
+            description = project.description
+            from(components.java)
+            pom {
+                description = project.description
+                url = website
+                inceptionYear = inceptionYear
                 licenses {
                     license {
-                        name 'GNU Library or Lesser General Public License (LGPL)'
-                        url 'http://www.gnu.org/licenses/lgpl.txt'
+                        name = 'GNU Library or Lesser General Public License (LGPL)'
+                        url = 'http://www.gnu.org/licenses/lgpl.txt'
                     }
                 }
                 developers {
                     developer {
-                        id owner1_id
-                        name owner1_name
-                        email owner1_email
+                        id = owner1_id
+                        name = owner1_name
+                        email = owner1_email
                     }
                     developer {
-                        id owner2_id
-                        name owner2_name
-                        email owner2_email
+                        id = owner2_id
+                        name = owner2_name
+                        email = owner2_email
                     }
                 }
                 scm {
-                    connection 'scm:git:git://github.com/eseifert/vectorgraphics2d.git'
-                    developerConnection 'scm:git:git@github.com:eseifert/vectorgraphics2d.git'
-                    url website
+                    connection = 'scm:git:git://github.com/eseifert/vectorgraphics2d.git'
+                    developerConnection = 'scm:git:git@github.com:eseifert/vectorgraphics2d.git'
+                    url = website
                 }
                 issueManagement {
-                    system 'GitHub Issues'
-                    url website
+                    system = 'GitHub Issues'
+                    url = website
                 }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'mavenRepo'
+            def releasesUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotsUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+
+            url = version.endsWith('-SNAPSHOT') ? snapshotsUrl : releasesUrl
+            if (project.hasProperty('ossrhUsername') &&
+                    project.hasProperty('ossrhPassword')) {
+                credentials.username = ossrhUsername
+                credentials.password = ossrhPassword
+            } else {
+                credentials.username = ''
+                credentials.password = ''
             }
         }
     }


### PR DESCRIPTION
This is an initial fix for the Gradle build (I ran it with Gradle 7.5.1). The build is not perfect but is a better base to work on, depending on the maintainer's technical decisions. (For example I'd personally get rid of the Proguard task)

If one runs `gradle build -x test` it completes just fine.

Remaining problems:

1) The `getPhysicalFontReturnsPhysicalFontForFontFamily` test fails.
2) The (now commented out) `license` plugin fails due to a number of missing headers. Once the problems are fixed, could be uncommented.
3) The creation of Jar files still need a few adjustments (which I didn't do because of the interaction with the Proguard task).
4) `gradle cobertura coveralls` fails with a number of errors, and the `coveralls-gradle-plugin` is not maintained anymore.